### PR TITLE
Donation address in LiquidVault switched to zero address, tests updated

### DIFF
--- a/contracts/LiquidVault.sol
+++ b/contracts/LiquidVault.sol
@@ -48,7 +48,6 @@ contract LiquidVault is Ownable {
         FeeDistributorLike feeDistributor;
         address self;
         address weth;
-        address donation;
         address payable ethReceiver;
         uint32 stakeDuration;
         uint8 donationShare; //0-100
@@ -71,7 +70,6 @@ contract LiquidVault is Ownable {
         uint32 duration,
         address hcore,
         address feeDistributor,
-        address donation,
         address payable ethReceiver,
         uint8 donationShare, // LP Token
         uint8 purchaseFee // ETH
@@ -86,20 +84,19 @@ contract LiquidVault is Ownable {
         config.feeDistributor = FeeDistributorLike(feeDistributor);
         config.weth = config.uniswapRouter.WETH();
         config.self = address(this);
-        setFeeAddresses(donation, ethReceiver);
+        setEthFeeAddress(ethReceiver);
         setParameters(duration, donationShare, purchaseFee);
     }
 
-    function setFeeAddresses(address donation, address payable ethReceiver)
+    function setEthFeeAddress(address payable ethReceiver)
         public
         onlyOwner
     {
         require(
-            donation != address(0) && ethReceiver != address(0),
-            "LiquidVault: donation and eth receiver are zero addresses"
+            ethReceiver != address(0),
+            "LiquidVault: eth receiver is zero address"
         );
 
-        config.donation = donation;
         config.ethReceiver = ethReceiver;
     }
 
@@ -204,7 +201,7 @@ contract LiquidVault is Ownable {
         uint256 donation = (config.donationShare * batch.amount) / 100;
         emit LPClaimed(msg.sender, batch.amount, block.timestamp, donation);
         require(
-            config.tokenPair.transfer(config.donation, donation),
+            config.tokenPair.transfer(address(0), donation),
             "HardCore: donation transfer failed in LP claim."
         );
         return config.tokenPair.transfer(batch.holder, batch.amount - donation);

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -4,7 +4,7 @@ const HardCore = artifacts.require('HardCore')
 const LiquidVault = artifacts.require('LiquidVault')
 const NFTFund = artifacts.require('NFTFund')
 
-const Uniswapfactory = artifacts.require('UniswapV2Factory.sol');
+const Uniswapfactory = artifacts.require('UniswapV2Factory.sol')
 const UniswapRouter = artifacts.require('UniswapV2Router02.sol')
 const WETH = artifacts.require('WETH')
 
@@ -27,7 +27,7 @@ module.exports = async function (deployer, network, accounts) {
     await deployer.deploy(LiquidVault)
     const liquidVaultInstance = await LiquidVault.deployed()
     await pausePromise('liquidity vault')
-
+    
 
     let uniswapfactoryInstance, uniswapRouterInstance
     if (network === 'development') {
@@ -60,7 +60,7 @@ module.exports = async function (deployer, network, accounts) {
     await pausePromise('seed fee approver')
     await feeApproverInstance.initialize(hardCoreInstance.address, factoryAddress, routerAddress, liquidVaultInstance.address)
     await pausePromise('seed liquid vault')
-    await liquidVaultInstance.seed(2, hardCoreInstance.address, feeDistributorInstance.address, accounts[3], accounts[1], 10, 10)
+    await liquidVaultInstance.seed(2, hardCoreInstance.address, feeDistributorInstance.address, NFTFund.address, 10, 10)
 }
 
 function pausePromise(message, durationInSeconds = 2) {


### PR DESCRIPTION
- [x] Donation address removed from seed() and setEthFeeAddress()
- [x] setFeeAddresses() renamed to setEthFeeAddress()
- [x] LP tokens are transferred to zero address in claimLP()
- [x] Unit tests & deployment script updated